### PR TITLE
build: add cloudflare workers types and pages output dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"web-vitals": "^5.1.0"
 			},
 			"devDependencies": {
+				"@cloudflare/workers-types": "^4.20241218.0",
 				"@eslint/js": "^9.25.0",
 				"@shadcn/ui": "^0.0.4",
 				"@tanstack/router-cli": "^1.121.13",
@@ -1154,6 +1155,13 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@cloudflare/workers-types": {
+			"version": "4.20251001.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251001.0.tgz",
+			"integrity": "sha512-MXseDjmqL1hIdQCqwHDMG8SE60W4FdwqLsofZjo/KtLH9zFcoQfZkCYyQrdfEJINiSoNJjrup7WR6KsqiFUSsg==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0"
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,6 +24,9 @@ compatibility_date = "2024-01-01"
 command = "npm run build"
 publish = "dist"
 
+# Pages build output directory
+pages_build_output_dir = "dist"
+
 # Functions configuration
 [functions]
 directory = "functions"


### PR DESCRIPTION
Add @cloudflare/workers-types dependency for type safety and specify pages build output directory in wrangler config