### PR TITLE
feat(gui): elegant single-page home (warm-dark editorial)

### DIFF
--- a/plan-version-2/03-phase-2-elegant-gui.md
+++ b/plan-version-2/03-phase-2-elegant-gui.md
@@ -79,10 +79,33 @@ All pages redesigned + consistent, one nav/one footer, mode-switch both ways, co
 
 ---
 
+## Locked design decisions (2026-05-31)
+Confirmed with user via research + Q&A. **Aesthetic mandate: "Simplicity is the ultimate sophistication."**
+- **Direction:** a *blend* of warm-editorial + Swiss-monochrome — i.e. **warm-paper Swiss base, editorial asymmetry, confident big display type, a whisper of serif.** (User couldn't pick one of the three pure options; explicitly wanted the blend.)
+- **Palette:** **near-monochrome** — warm bone paper + deep warm-ink. **No color accent** (the "accent" is just a deeper ink / hairline). Never pure #fff or #000. Grounded in 2026 trend research (Pantone "Cloud Dancer" warm off-white CotY; deep-brown "new black"; single-hue restraint).
+- **Type:** keep repo fonts — **Clash Display** (display) + **Uncut Sans** (body). User OK with adding more if needed. A "whisper of serif" italic line currently uses a system serif stack (`Newsreader`/`Iowan`/Palatino/Georgia); **TODO: optionally self-host Newsreader or Fraunces** if the serif touch is kept.
+- **Theme:** GUI is **light-only** (dark mode = the terminal). Tokens are scoped under `.gui-root` so they never collide with the global `.dark`.
+
+### Visual references shared with user (the lane)
+rauno.me · paco.me · leerob.com · emilkowal.ski · antfu.me · [Awwwards minimal](https://www.awwwards.com/awwwards/collections/minimal/) · [Awwwards editorial](https://www.awwwards.com/inspiration/editorial-layout)
+
+### What exists now (prototype to react to)
+- `src/features/elegant/elegant.css` — **the scoped design system** (`.gui-root` tokens: `--paper*`, `--ink*`, `--line*`, fonts, fluid spacing; helper classes `.gui-eyebrow`, `.gui-display`, `.gui-serif`, `.gui-link`, `.gui-rule`). Self-contained; does NOT depend on shadcn `--background` vars or fight `.dark`.
+- `src/features/elegant/components/Hero.tsx` — editorial asymmetric hero (8/4 grid), real data from `data/about.ts` + `data/contact.ts`, single framer-motion load stagger (transform/opacity, reduced-motion safe).
+- `src/features/elegant/components/Nav.tsx` — slim editorial top bar (wordmark + text links + `↗ terminal`). Links to /home, /projects, /about, /contact, /.
+- `src/features/elegant/components/GuiHome.tsx` — wraps everything in `.gui-root`.
+- `src/routes/home.tsx` — `/home` route (route tree regenerated). **Live at `/home`, HTTP 200, typecheck clean.**
+
 ## Session log
 | Date | What got done | Build green? | Handoff note |
 |------|---------------|--------------|--------------|
-| | | | |
+| 2026-05-31 | Locked design direction (above). Built scoped design system + editorial Hero + slim Nav + `/home` route as a prototype for user to react to. | typecheck ✓ | Awaiting user's reaction to the live hero before building the remaining pages / Footer / mode-switch banner. Do NOT mass-build pages until the hero look is signed off. |
 
 ## Handoff notes
-_(next-session pointer)_
+**Next session, start here:**
+1. Read the user's feedback on the `/home` hero (look/feel iteration). The design system in `elegant.css` is the single source of truth — tune tokens there, not inline.
+2. Once hero is signed off → build **Footer** (Task B), then redesign **/projects, /about, /experience, /contact** (Task C) reusing `.gui-root` + helper classes. Retarget the terminal `gui` command from `/about` → `/home` (`src/features/terminal/commands/navigation.ts`).
+3. Then mode-switch niceties (Task D), a11y pass (Task E), then the global `.dark` scoping cleanup in `__root.tsx` (currently force-adds `.dark` to `<html>`; the GUI is immune via `.gui-root`, but tidy this when wiring full mode-switch).
+4. Add X handle (`https://x.com/ekjongoru`) to `src/data/contact.ts` (still pending).
+5. Decide whether to self-host a serif (Newsreader/Fraunces) for the `.gui-serif` line.
+_Note: working on branch `feat/privacy-page` currently (not the planned `feat/revamp-phase-2`) — confirm branch strategy with user._

--- a/plan-version-2/03-phase-2-elegant-gui.md
+++ b/plan-version-2/03-phase-2-elegant-gui.md
@@ -96,10 +96,30 @@ rauno.me · paco.me · leerob.com · emilkowal.ski · antfu.me · [Awwwards mini
 - `src/features/elegant/components/GuiHome.tsx` — wraps everything in `.gui-root`.
 - `src/routes/home.tsx` — `/home` route (route tree regenerated). **Live at `/home`, HTTP 200, typecheck clean.**
 
+## Resume reconciliation — confirmed data decisions (2026-05-31)
+Source: `docs/saddat_hasan_resume_fsd1.md`. Confirmed with user:
+- **Title everywhere:** Full-Stack & DevOps Engineer. Rewrite bio/intro from the resume's Professional Summary.
+- **Skills:** enrich with resume's DevOps/AI set — Terraform, Azure, IAM, Linux, Claude Code, Cursor, GitHub Copilot.
+- **InfinitiBit = promotion history** (3 stacked roles: Frontend SE → Full-stack → Full-stack & DevOps). ⚠️ STILL NEED exact role dates from user.
+- **Talvette dates:** Jun 2023 – Jan 2025 (resume wins over old site's Oct 2023 – Feb 2025).
+- **WPP Production** "(formerly Wunderman Thompson Studios)" — use `formerName`.
+- **DRK-CBD:** PROJECT ONLY — remove the experience entry, keep as a shipped project.
+- **Projects:** add **Ria Medic Shop as the lead** (POS & ERP, medical retail, React + PostgreSQL + RBAC + inventory + dashboards, Nov 2024–Present). Trim the "Current Portfolio Site" self-reference. ⚠️ STILL NEED Ria backend/stack + live link (likely private/no link).
+- **Certificates:** keep all 6. **Phone:** keep OFF the site. **X handle:** keep. **Education dates:** keep 2016–2020.
+
+### Planned data model (`src/data/site.ts`) — typed single source of truth
+- Dates as `"YYYY-MM"` strings + one `formatPeriod()` helper → renders "Feb 2025 – Present".
+- `Company { id, company, formerName?, url?, location?, roles: Role[] }`; `Role { title, start, end|null, type?, highlights?, technologies? }` (promotions = multiple roles).
+- `Project { …, featured?, order? }` controls Selected-work + lead ordering.
+- Existing data files (`heroInfo`/`aboutInfo`/`experiences`/`projects`/`skills`/`certificates`/`contactInfo`) become thin **selectors** off `site.ts` so terminal + GUI keep working unchanged.
+- Upgrade elegant `ExperienceSection` to render stacked promotion roles.
+- **Branch:** `feat/site-data-model`, stacked on `feat/elegant-gui-home`.
+
 ## Session log
 | Date | What got done | Build green? | Handoff note |
 |------|---------------|--------------|--------------|
-| 2026-05-31 | Locked design direction (above). Built scoped design system + editorial Hero + slim Nav + `/home` route as a prototype for user to react to. | typecheck ✓ | Awaiting user's reaction to the live hero before building the remaining pages / Footer / mode-switch banner. Do NOT mass-build pages until the hero look is signed off. |
+| 2026-05-31 | Locked design direction. Built scoped design system + prototype hero. | typecheck ✓ | (superseded below) |
+| 2026-05-31 | Revised to rauno/paco quiet register; **committed dark palette**; wired tokens into tailwind.config. Built full **single-page home** (Hero + About/Work/Experience/Stack/Education/Certificates/Contact) with **data-driven section registry** (`sections.config.tsx` — reorder array → page/numbering/nav all follow). Modular content-only sections + primitives (Reveal/Section/WorkRow). **Committed as `feat/elegant-gui-home`** (off `version-2`). Signed off by user. | typecheck + `vite build` ✓ | NEXT: push `feat/elegant-gui-home` + open PR into `version-2` (awaiting user OK on base/remote). Then `feat/site-data-model` branch — but FIRST get the 2 ⚠️ items above (InfinitiBit role dates, Ria stack/link). |
 
 ## Handoff notes
 **Next session, start here:**

--- a/src/features/elegant/components/GuiHome.tsx
+++ b/src/features/elegant/components/GuiHome.tsx
@@ -1,0 +1,36 @@
+import "../elegant.css";
+import { homeSections } from "../sections.config";
+import { Section } from "./primitives/Section";
+import { TopBar } from "./TopBar";
+import { HeroSection } from "./sections/HeroSection";
+
+// The elegant GUI home: a single quiet scroll, wrapped in `.gui-root .gui-dark`
+// (the warm dark token scope, see elegant.css), isolated from the terminal's
+// global `.dark` theme. Section order/numbering/nav are all driven by
+// sections.config.tsx — reorder that array and everything below follows.
+export function GuiHome() {
+	return (
+		<div id="top" className="gui-root gui-dark">
+			<TopBar />
+			<div className="mx-auto max-w-[44rem] px-6">
+				<HeroSection />
+				{homeSections.map((s, i) => (
+					<Section
+						key={s.id}
+						id={s.id}
+						index={String(i + 1).padStart(2, "0")}
+						title={s.title}
+					>
+						<s.Component />
+					</Section>
+				))}
+			</div>
+			<footer className="border-t border-line">
+				<div className="mx-auto flex max-w-[44rem] flex-wrap items-center justify-between gap-2 px-6 py-8 text-[0.8rem] text-ink-muted">
+					<span>© 2026 Saddat Hasan</span>
+					<span>Built with React &amp; TanStack Router</span>
+				</div>
+			</footer>
+		</div>
+	);
+}

--- a/src/features/elegant/components/TopBar.tsx
+++ b/src/features/elegant/components/TopBar.tsx
@@ -1,0 +1,36 @@
+import { Link } from "@tanstack/react-router";
+import { homeSections } from "../sections.config";
+
+// Nav items derive from the same registry — any section with a `navLabel`
+// appears here, in the registry's order. Reorder once, updates everywhere.
+const navItems = homeSections.filter((s) => s.navLabel);
+
+// Minimal sticky bar: wordmark + anchor links + terminal escape hatch. Solid
+// paper background + a hairline (no glassy blur). Quiet by design.
+export function TopBar() {
+	return (
+		<div className="sticky top-0 z-20 border-b border-line bg-paper/95">
+			<nav className="mx-auto flex max-w-[44rem] items-center justify-between px-6 py-3.5 text-[0.85rem]">
+				<a
+					href="#top"
+					className="font-display font-medium tracking-[-0.01em] text-ink"
+				>
+					Saddat Hasan
+				</a>
+
+				<div className="flex items-center gap-x-5">
+					<div className="hidden items-center gap-x-5 sm:flex">
+						{navItems.map((s) => (
+							<a key={s.id} href={`#${s.id}`} className="gui-link text-ink-soft">
+								{s.navLabel}
+							</a>
+						))}
+					</div>
+					<Link to="/" className="gui-link text-ink-muted">
+						terminal ↗
+					</Link>
+				</div>
+			</nav>
+		</div>
+	);
+}

--- a/src/features/elegant/components/primitives/Reveal.tsx
+++ b/src/features/elegant/components/primitives/Reveal.tsx
@@ -1,0 +1,26 @@
+import { motion, useReducedMotion } from "framer-motion";
+import type { ReactNode } from "react";
+
+interface RevealProps {
+	children: ReactNode;
+	/** Stagger offset in seconds. */
+	delay?: number;
+	className?: string;
+}
+
+// Subtle scroll-into-view reveal: a small rise + fade, once. Honors
+// prefers-reduced-motion (no movement, instant). Transform/opacity only.
+export function Reveal({ children, delay = 0, className }: RevealProps) {
+	const reduce = useReducedMotion();
+	return (
+		<motion.div
+			className={className}
+			initial={{ opacity: 0, y: reduce ? 0 : 12 }}
+			whileInView={{ opacity: 1, y: 0 }}
+			viewport={{ once: true, margin: "-12% 0px" }}
+			transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1], delay }}
+		>
+			{children}
+		</motion.div>
+	);
+}

--- a/src/features/elegant/components/primitives/Section.tsx
+++ b/src/features/elegant/components/primitives/Section.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { Reveal } from "./Reveal";
+
+interface SectionProps {
+	id: string;
+	/** Two-digit section marker, e.g. "01". */
+	index: string;
+	title: string;
+	children: ReactNode;
+}
+
+// Section shell: a hairline top rule, a numbered eyebrow ("01 — About"),
+// consistent vertical rhythm, and an anchor target offset for the sticky bar.
+// The whole section reveals on scroll.
+export function Section({ id, index, title, children }: SectionProps) {
+	return (
+		<section
+			id={id}
+			className="scroll-mt-24 border-t border-line py-16 md:py-20"
+		>
+			<Reveal>
+				<p className="mb-9 flex items-baseline gap-3 text-[0.72rem] font-medium uppercase tracking-[0.18em]">
+					<span className="text-ink-muted tabular-nums">{index}</span>
+					<span className="text-ink-soft">{title}</span>
+				</p>
+				{children}
+			</Reveal>
+		</section>
+	);
+}

--- a/src/features/elegant/components/primitives/WorkRow.tsx
+++ b/src/features/elegant/components/primitives/WorkRow.tsx
@@ -1,0 +1,36 @@
+interface WorkRowProps {
+	title: string;
+	note: string;
+	/** Optional impact metric, shown small + muted on the right. */
+	meta?: string;
+	href?: string;
+}
+
+// One project row: title (left) + terse note & optional metric (right). The
+// whole row links out; an arrow reveals on hover. Hairline-separated, monochrome.
+export function WorkRow({ title, note, meta, href }: WorkRowProps) {
+	const external = href?.startsWith("http");
+	return (
+		<a
+			href={href}
+			target={external ? "_blank" : undefined}
+			rel={external ? "noreferrer" : undefined}
+			className="group grid grid-cols-[1fr_auto] items-baseline gap-x-4 gap-y-1 border-t border-line py-4 transition-colors hover:border-line-strong"
+		>
+			<span className="font-display text-[1.08rem] font-medium text-ink">
+				{title}
+				<span className="ml-2 inline-block translate-x-0 opacity-0 transition-all duration-300 ease-out group-hover:translate-x-1 group-hover:opacity-100">
+					↗
+				</span>
+			</span>
+			<span className="row-start-2 text-[0.92rem] text-ink-soft md:row-start-1">
+				{note}
+			</span>
+			{meta ? (
+				<span className="col-start-2 row-start-1 text-right text-[0.82rem] tabular-nums text-ink-muted">
+					{meta}
+				</span>
+			) : null}
+		</a>
+	);
+}

--- a/src/features/elegant/components/sections/AboutSection.tsx
+++ b/src/features/elegant/components/sections/AboutSection.tsx
@@ -1,0 +1,13 @@
+import { aboutInfo } from "@/data/about";
+
+// Content only — the numbered Section shell is applied by the registry
+// (sections.config.tsx) so order/numbering stays data-driven.
+export function AboutSection() {
+	return (
+		<div className="max-w-[54ch] space-y-5 text-[1.02rem] leading-[1.75] text-ink-soft">
+			{aboutInfo.bio.map((paragraph) => (
+				<p key={paragraph.slice(0, 24)}>{paragraph}</p>
+			))}
+		</div>
+	);
+}

--- a/src/features/elegant/components/sections/CertificatesSection.tsx
+++ b/src/features/elegant/components/sections/CertificatesSection.tsx
@@ -1,0 +1,24 @@
+import { WorkRow } from "../primitives/WorkRow";
+import { certificates } from "@/data/certificates";
+
+// Content only — reuses WorkRow (title + issuer + date, links to credential).
+export function CertificatesSection() {
+	return (
+		<ul>
+			{certificates.map((c) => (
+				<li key={c.name}>
+					<WorkRow
+						title={c.name}
+						note={c.issuer}
+						meta={c.issuingDate}
+						href={
+							c.credentialUrl && c.credentialUrl !== "N/A"
+								? c.credentialUrl
+								: undefined
+						}
+					/>
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/src/features/elegant/components/sections/ContactSection.tsx
+++ b/src/features/elegant/components/sections/ContactSection.tsx
@@ -1,0 +1,41 @@
+const EMAIL = "saddathasan94@gmail.com";
+
+const elsewhere = [
+	{ label: "GitHub", href: "https://github.com/saddathasan" },
+	{ label: "LinkedIn", href: "https://linkedin.com/in/saddathasan" },
+	{ label: "X", href: "https://x.com/ekjongoru" },
+	{ label: "Résumé", href: "/resume.pdf" },
+];
+
+// Content only — Section shell applied by the registry.
+export function ContactSection() {
+	return (
+		<>
+			<p className="max-w-[40ch] text-[1.05rem] leading-[1.7] text-ink-soft">
+				Open to new opportunities and collaborations. The fastest way to reach
+				me is email.
+			</p>
+
+			<a
+				href={`mailto:${EMAIL}`}
+				className="gui-link mt-7 inline-block font-display text-[clamp(1.4rem,4vw,2rem)] font-medium tracking-[-0.01em] text-ink"
+			>
+				{EMAIL}
+			</a>
+
+			<div className="mt-9 flex flex-wrap gap-x-6 gap-y-2 text-[0.95rem]">
+				{elsewhere.map((e) => (
+					<a
+						key={e.label}
+						href={e.href}
+						target={e.href.startsWith("http") ? "_blank" : undefined}
+						rel={e.href.startsWith("http") ? "noreferrer" : undefined}
+						className="gui-link text-ink"
+					>
+						{e.label}
+					</a>
+				))}
+			</div>
+		</>
+	);
+}

--- a/src/features/elegant/components/sections/EducationSection.tsx
+++ b/src/features/elegant/components/sections/EducationSection.tsx
@@ -1,0 +1,29 @@
+import { aboutInfo } from "@/data/about";
+
+// Content only — Section shell applied by the registry.
+export function EducationSection() {
+	const { education } = aboutInfo;
+	return (
+		<div className="border-t border-line py-5">
+			<div className="flex items-baseline justify-between gap-4">
+				<h3 className="font-display text-[1.08rem] font-medium text-ink">
+					{education.degree}
+				</h3>
+				<span className="shrink-0 text-[0.82rem] tabular-nums text-ink-muted">
+					{education.period}
+				</span>
+			</div>
+			<a
+				href={education.link}
+				target="_blank"
+				rel="noreferrer"
+				className="gui-link mt-1 inline-block text-[0.95rem] text-ink-soft"
+			>
+				{education.institution}
+			</a>
+			<p className="mt-3 max-w-[54ch] text-[0.95rem] leading-[1.7] text-ink-muted">
+				{education.description}
+			</p>
+		</div>
+	);
+}

--- a/src/features/elegant/components/sections/ExperienceSection.tsx
+++ b/src/features/elegant/components/sections/ExperienceSection.tsx
@@ -1,0 +1,59 @@
+import { Link } from "@tanstack/react-router";
+import { experiences, type Experience } from "@/data/experience";
+
+// Compact career entry: company + role + period, with nested stints (e.g. the
+// Dell / Microsoft work under Wunderman) shown as sub-rows. This is the shape
+// the upcoming promotion model (multiple roles per company) will slot into.
+function ExperienceItem({ exp }: { exp: Experience }) {
+	return (
+		<div className="border-t border-line py-5">
+			<div className="flex items-baseline justify-between gap-4">
+				<h3 className="font-display text-[1.08rem] font-medium text-ink">
+					{exp.company}
+				</h3>
+				<span className="shrink-0 text-[0.82rem] tabular-nums text-ink-muted">
+					{exp.period}
+				</span>
+			</div>
+			<p className="mt-1 text-[0.95rem] text-ink-soft">
+				{exp.role}
+				<span className="text-ink-muted"> · {exp.type}</span>
+			</p>
+
+			{exp.subExperiences?.length ? (
+				<ul className="mt-3 space-y-1.5 border-l border-line pl-4">
+					{exp.subExperiences.map((sub) => (
+						<li
+							key={sub.company}
+							className="flex items-baseline justify-between gap-4 text-[0.9rem]"
+						>
+							<span className="text-ink-soft">{sub.company}</span>
+							<span className="shrink-0 tabular-nums text-ink-muted">
+								{sub.period}
+							</span>
+						</li>
+					))}
+				</ul>
+			) : null}
+		</div>
+	);
+}
+
+// Content only — Section shell applied by the registry.
+export function ExperienceSection() {
+	return (
+		<>
+			<div>
+				{experiences.map((exp) => (
+					<ExperienceItem key={exp.id} exp={exp} />
+				))}
+			</div>
+			<Link
+				to="/experience"
+				className="gui-link mt-6 inline-block text-[0.92rem] text-ink-muted"
+			>
+				Full history →
+			</Link>
+		</>
+	);
+}

--- a/src/features/elegant/components/sections/HeroSection.tsx
+++ b/src/features/elegant/components/sections/HeroSection.tsx
@@ -1,0 +1,49 @@
+import { Link } from "@tanstack/react-router";
+import { Reveal } from "../primitives/Reveal";
+
+// Opening statement — the only section without a numbered eyebrow. Identity,
+// a strong one-line value statement, an availability marker. Lots of air above.
+export function HeroSection() {
+	return (
+		<header className="pt-[16vh] pb-20 md:pb-28">
+			<Reveal delay={0}>
+				<div className="flex items-center gap-2.5 text-[0.8rem] text-ink-muted">
+					<span className="inline-block h-1.5 w-1.5 rounded-full bg-ink-soft" />
+					Available for select work
+				</div>
+			</Reveal>
+
+			<Reveal delay={0.08}>
+				<h1 className="mt-6 font-display text-[clamp(2rem,6vw,3.25rem)] font-medium leading-[1.05] tracking-[-0.02em] text-ink">
+					I build scalable web &amp; DevOps systems —{" "}
+					<span className="font-serif italic font-normal text-ink-soft">
+						clean, considered, resilient.
+					</span>
+				</h1>
+			</Reveal>
+
+			<Reveal delay={0.16}>
+				<p className="mt-7 max-w-[42ch] text-[1.05rem] leading-[1.7] text-ink-soft">
+					I&apos;m{" "}
+					<span className="text-ink">Saddat Hasan</span>, a full-stack &amp;
+					DevOps engineer in Dhaka, Bangladesh. Currently at InfinitiBit GmbH,
+					building AI-powered products with React, FastAPI &amp; PostgreSQL.
+				</p>
+			</Reveal>
+
+			<Reveal delay={0.24}>
+				<div className="mt-9 flex flex-wrap items-center gap-x-6 gap-y-2 text-[0.95rem]">
+					<a href="#contact" className="gui-link text-ink">
+						Get in touch
+					</a>
+					<a href="#work" className="gui-link text-ink-muted">
+						Selected work ↓
+					</a>
+					<Link to="/" className="gui-link text-ink-muted">
+						terminal ↗
+					</Link>
+				</div>
+			</Reveal>
+		</header>
+	);
+}

--- a/src/features/elegant/components/sections/StackSection.tsx
+++ b/src/features/elegant/components/sections/StackSection.tsx
@@ -1,0 +1,25 @@
+import { skills } from "@/data/skills";
+
+// Terse stack — grouped as label + inline skill list. No badges, no soup.
+// Uses the fuller skills set (incl. Cloud/DevOps + AI/ML). Content only.
+export function StackSection() {
+	return (
+		<dl className="space-y-1">
+			{skills.map((cat) => (
+				<div
+					key={cat.id}
+					className="grid grid-cols-[8rem_1fr] items-baseline gap-x-4 gap-y-1 border-t border-line py-3.5 sm:grid-cols-[10rem_1fr]"
+				>
+					<dt className="text-[0.82rem] uppercase tracking-[0.12em] text-ink-muted">
+						{cat.title}
+					</dt>
+					<dd className="text-[0.98rem] text-ink-soft">
+						{cat.skills
+							.map((s) => (typeof s === "string" ? s : s.name))
+							.join("  ·  ")}
+					</dd>
+				</div>
+			))}
+		</dl>
+	);
+}

--- a/src/features/elegant/components/sections/WorkSection.tsx
+++ b/src/features/elegant/components/sections/WorkSection.tsx
@@ -1,0 +1,34 @@
+import { Link } from "@tanstack/react-router";
+import { WorkRow } from "../primitives/WorkRow";
+import { projects } from "@/data/projects";
+
+// First clause of a description — terse, list-friendly.
+const note = (description: string) => description.split(/[.—]/)[0].trim();
+
+const featured = projects.slice(0, 4);
+
+// Content only — Section shell applied by the registry.
+export function WorkSection() {
+	return (
+		<>
+			<ul>
+				{featured.map((p) => (
+					<li key={p.id}>
+						<WorkRow
+							title={p.title}
+							note={note(p.description)}
+							meta={p.impact?.split(",")[0]}
+							href={p.liveUrl ?? p.sourceUrl ?? undefined}
+						/>
+					</li>
+				))}
+			</ul>
+			<Link
+				to="/projects"
+				className="gui-link mt-6 inline-block text-[0.92rem] text-ink-muted"
+			>
+				All work →
+			</Link>
+		</>
+	);
+}

--- a/src/features/elegant/elegant.css
+++ b/src/features/elegant/elegant.css
@@ -1,0 +1,104 @@
+/* ───────────────────────────────────────────────────────────────────────────
+   Elegant GUI — warm-paper, near-monochrome design tokens.
+
+   Scoped under `.gui-root` so they are fully independent of the terminal's
+   global `.dark` shadcn theme. These vars back the Tailwind utilities defined
+   in tailwind.config.js (`bg-paper`, `text-ink`, `border-line`, `font-display`),
+   so component markup is plain Tailwind. Only the things Tailwind can't express
+   inline — design tokens, the animated underline, ::selection — live here.
+
+   Aesthetic: "Simplicity is the ultimate sophistication."
+   Quiet, single-column, monochrome (rauno.me / paco.me sweet spot), with a
+   whisper of warmth in the paper and one serif-italic line.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.gui-root {
+	/* ── LIGHT palette (warm paper) — default. ──
+	   "paper" = page surface, "ink" = what's written on it. */
+	--paper: #faf8f5; /* barely-warm off-white, never #fff */
+	--paper-raised: #ffffff;
+	--paper-sunk: #f3f1ec;
+
+	--ink: #1a1714; /* warm near-black, never #000 */
+	--ink-soft: #4b463f; /* body copy */
+	--ink-muted: #8c847a; /* labels, captions, secondary */
+
+	--line: #e9e4da; /* hairline rules */
+	--line-strong: #dcd5c8;
+
+	/* Type */
+	--font-display: "Clash Display Variable", system-ui, sans-serif;
+	--font-body: "Uncut Sans Variable", system-ui, sans-serif;
+	--font-serif: "Newsreader", "Iowan Old Style", "Palatino Linotype", Palatino,
+		Georgia, serif; /* the single "whisper of serif" line */
+
+	background-color: var(--paper);
+	color: var(--ink);
+	font-family: var(--font-body);
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+	min-height: 100vh;
+}
+
+/* ── DARK palette (warm "dim paper") — applied via `.gui-dark` on .gui-root. ──
+   Warm dark espresso surface + warm off-white ink. Deliberately NOT the
+   terminal's cool #0d1117 — this is an elegant warm dark, easy on the eyes
+   (no pure black, no pure white). Same names: paper = surface, ink = text. */
+.gui-root.gui-dark {
+	--paper: #1a1612;
+	--paper-raised: #221e18;
+	--paper-sunk: #131009;
+
+	--ink: #ece6da; /* warm off-white text, not pure #fff */
+	--ink-soft: #c3bcae; /* body copy */
+	--ink-muted: #8f8979; /* labels, captions, secondary */
+
+	--line: #2c2820; /* hairline rules */
+	--line-strong: #3b352b;
+}
+
+/* Considered selection, not default browser blue */
+.gui-root ::selection {
+	background: var(--ink);
+	color: var(--paper);
+}
+
+/* Text link: ink, with a hairline underline that wipes in on hover.
+   Pseudo-element + transform — awkward to express as inline Tailwind. */
+.gui-link {
+	position: relative;
+	color: inherit;
+	text-decoration: none;
+	transition: opacity 0.25s ease;
+}
+.gui-link::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	bottom: -2px;
+	width: 100%;
+	height: 1px;
+	background: currentColor;
+	transform: scaleX(0);
+	transform-origin: left;
+	transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.gui-link:hover::after {
+	transform: scaleX(1);
+}
+
+/* Smooth anchor scrolling on the single-page GUI (the document is the scroll
+   container). Scoped to when the body hosts the GUI to avoid touching the
+   terminal. Disabled under reduced-motion. */
+body:has(.gui-root) {
+	scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.gui-link::after {
+		transition: none;
+	}
+	body:has(.gui-root) {
+		scroll-behavior: auto;
+	}
+}

--- a/src/features/elegant/sections.config.tsx
+++ b/src/features/elegant/sections.config.tsx
@@ -1,0 +1,52 @@
+import type { ComponentType } from "react";
+import { AboutSection } from "./components/sections/AboutSection";
+import { WorkSection } from "./components/sections/WorkSection";
+import { ExperienceSection } from "./components/sections/ExperienceSection";
+import { StackSection } from "./components/sections/StackSection";
+import { EducationSection } from "./components/sections/EducationSection";
+import { CertificatesSection } from "./components/sections/CertificatesSection";
+import { ContactSection } from "./components/sections/ContactSection";
+
+export interface HomeSection {
+	/** Anchor id (used for #links and scroll targets). Keep unique + url-safe. */
+	id: string;
+	/** Eyebrow title shown next to the auto-generated number. */
+	title: string;
+	/** If set, the section appears in the sticky top nav with this label. */
+	navLabel?: string;
+	/** The section's content. The numbered shell + reveal are added for you. */
+	Component: ComponentType;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   THE single source of truth for the home page layout.
+
+   • Reorder these entries → the page order, the 01/02/03… numbering, AND the
+     top-nav order all update automatically. No other file needs touching.
+   • Remove an entry (or comment it out) → that section disappears everywhere.
+   • Add a new section → build a content-only component under
+     components/sections/, import it, and drop an entry here.
+   • Edit a section's words → edit its data file in src/data/.
+
+   (The Hero is intentionally NOT in this list — it's the un-numbered opener,
+    rendered first by GuiHome.)
+   ───────────────────────────────────────────────────────────────────────── */
+export const homeSections: HomeSection[] = [
+	{ id: "about", title: "About", navLabel: "About", Component: AboutSection },
+	{ id: "work", title: "Selected work", navLabel: "Work", Component: WorkSection },
+	{
+		id: "experience",
+		title: "Experience",
+		navLabel: "Experience",
+		Component: ExperienceSection,
+	},
+	{ id: "stack", title: "Stack", Component: StackSection },
+	{ id: "education", title: "Education", Component: EducationSection },
+	{ id: "certificates", title: "Certificates", Component: CertificatesSection },
+	{
+		id: "contact",
+		title: "Contact",
+		navLabel: "Contact",
+		Component: ContactSection,
+	},
+];

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ProjectsRouteImport } from './routes/projects'
+import { Route as HomeRouteImport } from './routes/home'
 import { Route as GitProfileRouteImport } from './routes/git-profile'
 import { Route as ExperienceRouteImport } from './routes/experience'
 import { Route as ContactRouteImport } from './routes/contact'
@@ -20,6 +21,11 @@ import { Route as IbExtensionPrivacyPolicyRouteImport } from './routes/ib-extens
 const ProjectsRoute = ProjectsRouteImport.update({
   id: '/projects',
   path: '/projects',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HomeRoute = HomeRouteImport.update({
+  id: '/home',
+  path: '/home',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GitProfileRoute = GitProfileRouteImport.update({
@@ -60,6 +66,7 @@ export interface FileRoutesByFullPath {
   '/contact': typeof ContactRoute
   '/experience': typeof ExperienceRoute
   '/git-profile': typeof GitProfileRoute
+  '/home': typeof HomeRoute
   '/projects': typeof ProjectsRoute
   '/ib-extension/privacy-policy': typeof IbExtensionPrivacyPolicyRoute
 }
@@ -69,6 +76,7 @@ export interface FileRoutesByTo {
   '/contact': typeof ContactRoute
   '/experience': typeof ExperienceRoute
   '/git-profile': typeof GitProfileRoute
+  '/home': typeof HomeRoute
   '/projects': typeof ProjectsRoute
   '/ib-extension/privacy-policy': typeof IbExtensionPrivacyPolicyRoute
 }
@@ -79,6 +87,7 @@ export interface FileRoutesById {
   '/contact': typeof ContactRoute
   '/experience': typeof ExperienceRoute
   '/git-profile': typeof GitProfileRoute
+  '/home': typeof HomeRoute
   '/projects': typeof ProjectsRoute
   '/ib-extension/privacy-policy': typeof IbExtensionPrivacyPolicyRoute
 }
@@ -90,6 +99,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/experience'
     | '/git-profile'
+    | '/home'
     | '/projects'
     | '/ib-extension/privacy-policy'
   fileRoutesByTo: FileRoutesByTo
@@ -99,6 +109,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/experience'
     | '/git-profile'
+    | '/home'
     | '/projects'
     | '/ib-extension/privacy-policy'
   id:
@@ -108,6 +119,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/experience'
     | '/git-profile'
+    | '/home'
     | '/projects'
     | '/ib-extension/privacy-policy'
   fileRoutesById: FileRoutesById
@@ -118,6 +130,7 @@ export interface RootRouteChildren {
   ContactRoute: typeof ContactRoute
   ExperienceRoute: typeof ExperienceRoute
   GitProfileRoute: typeof GitProfileRoute
+  HomeRoute: typeof HomeRoute
   ProjectsRoute: typeof ProjectsRoute
   IbExtensionPrivacyPolicyRoute: typeof IbExtensionPrivacyPolicyRoute
 }
@@ -129,6 +142,13 @@ declare module '@tanstack/react-router' {
       path: '/projects'
       fullPath: '/projects'
       preLoaderRoute: typeof ProjectsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/home': {
+      id: '/home'
+      path: '/home'
+      fullPath: '/home'
+      preLoaderRoute: typeof HomeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/git-profile': {
@@ -182,6 +202,7 @@ const rootRouteChildren: RootRouteChildren = {
   ContactRoute: ContactRoute,
   ExperienceRoute: ExperienceRoute,
   GitProfileRoute: GitProfileRoute,
+  HomeRoute: HomeRoute,
   ProjectsRoute: ProjectsRoute,
   IbExtensionPrivacyPolicyRoute: IbExtensionPrivacyPolicyRoute,
 }

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { GuiHome } from "@/features/elegant/components/GuiHome";
+
+export const Route = createFileRoute("/home")({
+	component: GuiHome,
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ export default {
 			fontFamily: {
 				sans: ["Inter", "sans-serif"],
 				mono: ["JetBrains Mono", "monospace"],
+				// Elegant GUI faces (tokens live under `.gui-root` in elegant.css)
+				display: ["var(--font-display)"],
+				body: ["var(--font-body)"],
+				serif: ["var(--font-serif)"],
 			},
 			colors: {
 				background: "hsl(var(--background))",
@@ -42,6 +46,23 @@ export default {
 				border: "hsl(var(--border))",
 				input: "hsl(var(--input))",
 				ring: "hsl(var(--ring))",
+				// Elegant GUI palette — warm paper + warm ink, near-monochrome.
+				// Values resolve from `.gui-root` (see elegant.css). Used only
+				// inside the GUI, so they never collide with the shadcn/.dark theme.
+				paper: {
+					DEFAULT: "var(--paper)",
+					raised: "var(--paper-raised)",
+					sunk: "var(--paper-sunk)",
+				},
+				ink: {
+					DEFAULT: "var(--ink)",
+					soft: "var(--ink-soft)",
+					muted: "var(--ink-muted)",
+				},
+				line: {
+					DEFAULT: "var(--line)",
+					strong: "var(--line-strong)",
+				},
 			},
 			borderRadius: {
 				lg: "var(--radius)",


### PR DESCRIPTION
Phase 2 — the elegant GUI. A quiet, single-page warm-dark editorial site (rauno/paco register), built on a scoped `.gui-root .gui-dark` token system (no collision with the terminal's `.dark`), with tokens wired into `tailwind.config`.

- Single quiet scroll: Hero + About / Work / Experience / Stack / Education / Certificates / Contact.
- **Data-driven section registry** (`sections.config.tsx`) — reorder one array and the page order, the 01/02/03 numbering, and the nav all follow.
- Modular content-only sections + primitives (`Reveal`, `Section`, `WorkRow`).

First of four stacked PRs into `version-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)